### PR TITLE
update delete command to delete deployment

### DIFF
--- a/5-Kubernetes-Basics.md
+++ b/5-Kubernetes-Basics.md
@@ -44,14 +44,15 @@ Do you see your pods in the list? It should look like this:
 
 ```
 $ kubectl get pods
-NAME          READY   STATUS              RESTARTS   AGE
-devopsgirls   0/1     ContainerCreating   0          2m41s
+
+NAME                           READY   STATUS              RESTARTS   AGE
+devopsgirls-xxxxxxxxxx-xxxxx   0/1     ContainerCreating   0          2m41s
 ```
 
 If you're happy with that, we can remove the pod with the following command:
 
 ```
-kubectl delete pod devopsgirls
+kubectl delete deployment devopsgirls
 ```
 
 And we're cleaned up!


### PR DESCRIPTION
As discussed in discord:

It looks like `kubectl run` by default also creates a Deployment, and so by deleting the Pod itself it does not delete the Deployment, and so it spins up another pod.

Updating the instructions to match the results of the `kubectl run` command